### PR TITLE
Fix Padding error in Format-Menuitem

### DIFF
--- a/PSMenu/Private/Format-MenuItem.ps1
+++ b/PSMenu/Private/Format-MenuItem.ps1
@@ -20,7 +20,7 @@ function Format-MenuItem(
     $WindowWidth = (Get-Host).UI.RawUI.WindowSize.Width
 
     $Text = "{0}{1}{2}" -f $FocusPrefix, $SelectionPrefix, $ItemText
-    if ($WindowWidth - ($Text.Length + 2) > 0) {
+    if ($WindowWidth - ($Text.Length + 2) -gt 0) {
         $Text = $Text.PadRight($WindowWidth - ($Text.Length + 2), ' ')
     }
     

--- a/PSMenu/Private/Format-MenuItem.ps1
+++ b/PSMenu/Private/Format-MenuItem.ps1
@@ -20,8 +20,10 @@ function Format-MenuItem(
     $WindowWidth = (Get-Host).UI.RawUI.WindowSize.Width
 
     $Text = "{0}{1}{2}" -f $FocusPrefix, $SelectionPrefix, $ItemText
-    $Text = $Text.PadRight($WindowWidth - ($Text.Length + 2), ' ')
-
+    if ($WindowWidth - ($Text.Length + 2) > 0) {
+        $Text = $Text.PadRight($WindowWidth - ($Text.Length + 2), ' ')
+    }
+    
     Return $Text
 }
 


### PR DESCRIPTION
Fixes long text in to small windows

To produce the error, resize the powershell window to a size where the longest item does not fit on a single line and run:
```Powershell
Show-Menu -MenuItems @("Item A1234567890B1234567890","Item A1234567890B1234567890C1234567890D1234567890E1234567890F1234567890G1234567890")
``` 
and receive
```
Format-MenuItem : Exceptioncalling "PadRight" with "2" argument(s): "Non-negative number required. Parameter name: totalWidth"
At C:\Program Files\WindowsPowerShell\Modules\PSMenu\0.1.0\Private\Write-Menu.ps1:40 char:24
+ ... splayText = Format-MenuItem-MenuItem $MenuItemStr -MultiSelect:$Mult ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Format-MenuItem], MethodInvocationException
    + FullyQualifiedErrorId : ArgumentOutOfRangeException,Format -MenuItem
```