### PR TITLE
fix an error that occurs in case of multi-selection and no-selections

### DIFF
--- a/PSMenu/Public/Show-Menu.ps1
+++ b/PSMenu/Public/Show-Menu.ps1
@@ -88,7 +88,7 @@ function Show-Menu {
         [Switch]$MultiSelect, 
         [ConsoleColor] $ItemFocusColor = [ConsoleColor]::Green,
         [ScriptBlock] $MenuItemFormatter = { Param($M) Format-MenuItemDefault $M },
-        [Array] $InitialSelection
+        [Array] $InitialSelection = @()
     )
 
     Test-HostSupported


### PR DESCRIPTION
#6 introduces a bug, sorry.

Using `-MultiSelection`, select nothing and press “Enter” hits a bug.

```
InvalidOperation: C:\Users\kazuki\Documents\PowerShell\Modules\PSMenu\0.1.2\Public\Show-Menu.ps1:151
Line |
 151 |              Return $MenuItems[$CurrentSelection]
     |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Index operation failed; the array index evaluated to null.
```