### PR TITLE
Fixing error when nothing is selected in multi-select mode

### DIFF
--- a/PSMenu/Public/Show-Menu.ps1
+++ b/PSMenu/Public/Show-Menu.ps1
@@ -148,7 +148,9 @@ function Show-Menu {
 
     if ($ReturnIndex -eq $false -and $null -ne $Position) {
         if ($MultiSelect) {
-            Return $MenuItems[$CurrentSelection]
+            if ($null -ne $CurrentSelection) {
+                Return $MenuItems[$CurrentSelection]
+            }
         }
         else {
             Return $MenuItems[$Position]


### PR DESCRIPTION
Fixes: If I use the MultiSelect mode, don't select anything and press enter, I get a exception